### PR TITLE
GeoComResponse return code refactor

### DIFF
--- a/src/geocompy/protocols.py
+++ b/src/geocompy/protocols.py
@@ -100,12 +100,13 @@ class GeoComResponse(Generic[_P]):
         """Full, serialized request, that invoked this response."""
         self.response: str = response
         """Full, received response."""
-        self.comcode: GeoComReturnCode = comcode
-        """Parsed COM return code indicating the success/failure of
-            communication."""
-        self.rpccode: GeoComReturnCode = rpccode
-        """Parsed RPC return code indicating the success/failure of
-            the command."""
+        self.code: GeoComReturnCode = (
+            comcode
+            if comcode.value == 0
+            else rpccode
+        )
+        """Parsed return code indicating the success/failure of the
+        request."""
         self.trans: int = trans
         """Parsed transaction ID."""
         self.params: _P | None = params
@@ -114,15 +115,14 @@ class GeoComResponse(Generic[_P]):
 
     def __str__(self) -> str:
         return (
-            f"GeoComResponse({self.rpcname}) com: {self.comcode.name:s}, "
-            f"rpc: {self.rpccode.name:s}, "
+            f"GeoComResponse({self.rpcname}) code: {self.code.name:s}, "
             f"tr: {self.trans:d}, "
             f"params: {self.params}, "
             f"(cmd: '{self.cmd}', response: '{self.response}')"
         )
 
     def __bool__(self) -> bool:
-        return bool(self.comcode) and bool(self.rpccode)
+        return bool(self.code)
 
     def map_params(
         self,
@@ -151,8 +151,8 @@ class GeoComResponse(Generic[_P]):
             self.rpcname,
             self.cmd,
             self.response,
-            self.comcode,
-            self.rpccode,
+            self.code,
+            self.code,
             self.trans,
             params
         )

--- a/src/geocompy/protocols.py
+++ b/src/geocompy/protocols.py
@@ -38,6 +38,9 @@ _P = TypeVar("_P", bound=Any)
 class GeoComReturnCode(IntEnum):
     """Base class for all GeoCom return code enums."""
 
+    def __bool__(self) -> bool:
+        return self == 0
+
 
 class GeoComResponse(Generic[_P]):
     """

--- a/src/geocompy/protocols.py
+++ b/src/geocompy/protocols.py
@@ -100,7 +100,7 @@ class GeoComResponse(Generic[_P]):
         """Full, serialized request, that invoked this response."""
         self.response: str = response
         """Full, received response."""
-        self.code: GeoComReturnCode = (
+        self.error: GeoComReturnCode = (
             comcode
             if comcode.value == 0
             else rpccode
@@ -115,14 +115,14 @@ class GeoComResponse(Generic[_P]):
 
     def __str__(self) -> str:
         return (
-            f"GeoComResponse({self.rpcname}) code: {self.code.name:s}, "
+            f"GeoComResponse({self.rpcname}) code: {self.error.name:s}, "
             f"tr: {self.trans:d}, "
             f"params: {self.params}, "
             f"(cmd: '{self.cmd}', response: '{self.response}')"
         )
 
     def __bool__(self) -> bool:
-        return bool(self.code)
+        return bool(self.error)
 
     def map_params(
         self,
@@ -151,8 +151,8 @@ class GeoComResponse(Generic[_P]):
             self.rpcname,
             self.cmd,
             self.response,
-            self.code,
-            self.code,
+            self.error,
+            self.error,
             self.trans,
             params
         )

--- a/src/geocompy/protocols.py
+++ b/src/geocompy/protocols.py
@@ -105,7 +105,7 @@ class GeoComResponse(Generic[_P]):
         """Full, received response."""
         self.error: GeoComReturnCode = (
             comcode
-            if comcode.value == 0
+            if comcode
             else rpccode
         )
         """Parsed return code indicating the success/failure of the

--- a/src/geocompy/protocols.py
+++ b/src/geocompy/protocols.py
@@ -105,7 +105,7 @@ class GeoComResponse(Generic[_P]):
         """Full, received response."""
         self.error: GeoComReturnCode = (
             comcode
-            if comcode
+            if not comcode
             else rpccode
         )
         """Parsed return code indicating the success/failure of the

--- a/src/geocompy/tps1000/__init__.py
+++ b/src/geocompy/tps1000/__init__.py
@@ -173,8 +173,7 @@ class TPS1000(GeoComProtocol):
         for i in range(retry):
             try:
                 self._conn.send("\n")
-                response = self.com.nullprocess()
-                if not response.error:
+                if self.com.nullprocess():
                     sleep(1)
                     break
             except Exception:

--- a/src/geocompy/tps1000/__init__.py
+++ b/src/geocompy/tps1000/__init__.py
@@ -373,20 +373,20 @@ class TPS1000(GeoComProtocol):
         except SerialTimeoutException:
             self._logger.error(format_exc())
             answer = (
-                f"%R1P,{TPS1000RC.COM_TIMEDOUT.value:d},"
-                f"0:{TPS1000RC.FATAL.value:d}"
+                f"%R1P,{TPS1000RC.COM_TIMEDOUT:d},"
+                f"0:{TPS1000RC.OK:d}"
             )
         except SerialException:
             self._logger.error(format_exc())
             answer = (
-                f"%R1P,{TPS1000RC.COM_CANT_SEND.value:d},"
-                f"0:{TPS1000RC.FATAL.value:d}"
+                f"%R1P,{TPS1000RC.COM_CANT_SEND:d},"
+                f"0:{TPS1000RC.OK:d}"
             )
         except Exception:
             self._logger.error(format_exc())
             answer = (
-                f"%R1P,{TPS1000RC.FATAL.value:d},"
-                f"0:{TPS1000RC.FATAL.value:d}"
+                f"%R1P,{TPS1000RC.COM_FAILED:d},"
+                f"0:{TPS1000RC.OK:d}"
             )
 
         response = self.parse_response(

--- a/src/geocompy/tps1000/__init__.py
+++ b/src/geocompy/tps1000/__init__.py
@@ -174,7 +174,7 @@ class TPS1000(GeoComProtocol):
             try:
                 self._conn.send("\n")
                 response = self.com.nullprocess()
-                if response.comcode and response.rpccode:
+                if not response.error:
                     sleep(1)
                     break
             except Exception:
@@ -244,7 +244,7 @@ class TPS1000(GeoComProtocol):
         get_double_precision
         """
         response: GeoComResponse[None] = self.request(107, [digits])
-        if response.comcode and response.rpccode:
+        if not response.error:
             self._precision = digits
         return response
 
@@ -461,7 +461,7 @@ class TPS1000(GeoComProtocol):
                 cmd,
                 response,
                 TPS1000RC.COM_CANT_DECODE,
-                TPS1000RC.UNDEFINED,
+                TPS1000RC.OK,
                 0
             )
 
@@ -485,7 +485,7 @@ class TPS1000(GeoComProtocol):
                 cmd,
                 response,
                 TPS1000RC.COM_CANT_DECODE,
-                TPS1000RC.UNDEFINED,
+                TPS1000RC.OK,
                 0
             )
 

--- a/src/geocompy/tps1100/__init__.py
+++ b/src/geocompy/tps1100/__init__.py
@@ -379,20 +379,20 @@ class TPS1100(GeoComProtocol):
         except SerialTimeoutException:
             self._logger.error(format_exc())
             answer = (
-                f"%R1P,{TPS1100RC.COM_TIMEDOUT.value:d},"
-                f"0:{TPS1100RC.FATAL.value:d}"
+                f"%R1P,{TPS1100RC.COM_TIMEDOUT:d},"
+                f"0:{TPS1100RC.OK:d}"
             )
         except SerialException:
             self._logger.error(format_exc())
             answer = (
-                f"%R1P,{TPS1100RC.COM_CANT_SEND.value:d},"
-                f"0:{TPS1100RC.FATAL.value:d}"
+                f"%R1P,{TPS1100RC.COM_CANT_SEND:d},"
+                f"0:{TPS1100RC.OK:d}"
             )
         except Exception:
             self._logger.error(format_exc())
             answer = (
-                f"%R1P,{TPS1100RC.FATAL.value:d},"
-                f"0:{TPS1100RC.FATAL.value:d}"
+                f"%R1P,{TPS1100RC.COM_FAILED:d},"
+                f"0:{TPS1100RC.OK:d}"
             )
 
         response = self.parse_response(

--- a/src/geocompy/tps1100/__init__.py
+++ b/src/geocompy/tps1100/__init__.py
@@ -180,7 +180,7 @@ class TPS1100(GeoComProtocol):
             try:
                 self._conn.send("\n")
                 response = self.com.nullprocess()
-                if response.comcode and response.rpccode:
+                if not response.error:
                     sleep(1)
                     break
             except Exception:
@@ -250,7 +250,7 @@ class TPS1100(GeoComProtocol):
         get_double_precision
         """
         response: GeoComResponse[None] = self.request(107, [digits])
-        if response.comcode and response.rpccode:
+        if not response.error:
             self._precision = digits
         return response
 
@@ -467,7 +467,7 @@ class TPS1100(GeoComProtocol):
                 cmd,
                 response,
                 TPS1100RC.COM_CANT_DECODE,
-                TPS1100RC.UNDEFINED,
+                TPS1100RC.OK,
                 0
             )
 
@@ -491,7 +491,7 @@ class TPS1100(GeoComProtocol):
                 cmd,
                 response,
                 TPS1100RC.COM_CANT_DECODE,
-                TPS1100RC.UNDEFINED,
+                TPS1100RC.OK,
                 0
             )
 

--- a/src/geocompy/tps1100/__init__.py
+++ b/src/geocompy/tps1100/__init__.py
@@ -179,8 +179,7 @@ class TPS1100(GeoComProtocol):
         for i in range(retry):
             try:
                 self._conn.send("\n")
-                response = self.com.nullprocess()
-                if not response.error:
+                if self.com.nullprocess():
                     sleep(1)
                     break
             except Exception:

--- a/src/geocompy/tps1200p/__init__.py
+++ b/src/geocompy/tps1200p/__init__.py
@@ -179,8 +179,7 @@ class TPS1200P(GeoComProtocol):
         for i in range(retry):
             try:
                 self._conn.send("\n")
-                response = self.com.nullprocess()
-                if not response.error:
+                if self.com.nullprocess():
                     sleep(1)
                     break
             except Exception:

--- a/src/geocompy/tps1200p/__init__.py
+++ b/src/geocompy/tps1200p/__init__.py
@@ -379,20 +379,20 @@ class TPS1200P(GeoComProtocol):
         except SerialTimeoutException:
             self._logger.error(format_exc())
             answer = (
-                f"%R1P,{TPS1200PGRC.COM_TIMEDOUT.value:d},"
-                f"0:{TPS1200PGRC.FATAL.value:d}"
+                f"%R1P,{TPS1200PGRC.COM_TIMEDOUT:d},"
+                f"0:{TPS1200PGRC.OK:d}"
             )
         except SerialException:
             self._logger.error(format_exc())
             answer = (
-                f"%R1P,{TPS1200PGRC.COM_CANT_SEND.value:d},"
-                f"0:{TPS1200PGRC.FATAL.value:d}"
+                f"%R1P,{TPS1200PGRC.COM_CANT_SEND:d},"
+                f"0:{TPS1200PGRC.OK:d}"
             )
         except Exception:
             self._logger.error(format_exc())
             answer = (
-                f"%R1P,{TPS1200PGRC.FATAL.value:d},"
-                f"0:{TPS1200PGRC.FATAL.value:d}"
+                f"%R1P,{TPS1200PGRC.COM_FAILED:d},"
+                f"0:{TPS1200PGRC.OK:d}"
             )
 
         response = self.parse_response(

--- a/src/geocompy/tps1200p/__init__.py
+++ b/src/geocompy/tps1200p/__init__.py
@@ -180,7 +180,7 @@ class TPS1200P(GeoComProtocol):
             try:
                 self._conn.send("\n")
                 response = self.com.nullprocess()
-                if response.comcode and response.rpccode:
+                if not response.error:
                     sleep(1)
                     break
             except Exception:
@@ -250,7 +250,7 @@ class TPS1200P(GeoComProtocol):
         get_double_precision
         """
         response: GeoComResponse[None] = self.request(107, [digits])
-        if response.comcode and response.rpccode:
+        if not response.error:
             self._precision = digits
         return response
 
@@ -467,7 +467,7 @@ class TPS1200P(GeoComProtocol):
                 cmd,
                 response,
                 TPS1200PGRC.COM_CANT_DECODE,
-                TPS1200PGRC.UNDEFINED,
+                TPS1200PGRC.OK,
                 0
             )
 
@@ -491,7 +491,7 @@ class TPS1200P(GeoComProtocol):
                 cmd,
                 response,
                 TPS1200PGRC.COM_CANT_DECODE,
-                TPS1200PGRC.UNDEFINED,
+                TPS1200PGRC.OK,
                 0
             )
 

--- a/src/geocompy/vivatps/__init__.py
+++ b/src/geocompy/vivatps/__init__.py
@@ -397,20 +397,20 @@ class VivaTPS(GeoComProtocol):
         except SerialTimeoutException:
             self._logger.error(format_exc())
             answer = (
-                f"%R1P,{VivaTPSGRC.COM_TIMEDOUT.value:d},"
-                f"0:{VivaTPSGRC.FATAL.value:d}"
+                f"%R1P,{VivaTPSGRC.COM_TIMEDOUT:d},"
+                f"0:{VivaTPSGRC.OK:d}"
             )
         except SerialException:
             self._logger.error(format_exc())
             answer = (
-                f"%R1P,{VivaTPSGRC.COM_CANT_SEND.value:d},"
-                f"0:{VivaTPSGRC.FATAL.value:d}"
+                f"%R1P,{VivaTPSGRC.COM_CANT_SEND:d},"
+                f"0:{VivaTPSGRC.OK:d}"
             )
         except Exception:
             self._logger.error(format_exc())
             answer = (
-                f"%R1P,{VivaTPSGRC.FATAL.value:d},"
-                f"0:{VivaTPSGRC.FATAL.value:d}"
+                f"%R1P,{VivaTPSGRC.COM_FAILED:d},"
+                f"0:{VivaTPSGRC.OK:d}"
             )
 
         response = self.parse_response(

--- a/src/geocompy/vivatps/__init__.py
+++ b/src/geocompy/vivatps/__init__.py
@@ -193,7 +193,7 @@ class VivaTPS(GeoComProtocol):
             try:
                 self._conn.send("\n")
                 response = self.com.nullprocess()
-                if response.comcode and response.rpccode:
+                if not response.error:
                     sleep(1)
                     break
             except Exception:
@@ -265,7 +265,7 @@ class VivaTPS(GeoComProtocol):
 
         """
         response: GeoComResponse[None] = self.request(107, [digits])
-        if response.comcode and response.rpccode:
+        if not response.error:
             self._precision = digits
         return response
 
@@ -486,7 +486,7 @@ class VivaTPS(GeoComProtocol):
                 cmd,
                 response,
                 VivaTPSGRC.COM_CANT_DECODE,
-                VivaTPSGRC.UNDEFINED,
+                VivaTPSGRC.OK,
                 0
             )
 
@@ -510,7 +510,7 @@ class VivaTPS(GeoComProtocol):
                 cmd,
                 response,
                 VivaTPSGRC.COM_CANT_DECODE,
-                VivaTPSGRC.UNDEFINED,
+                VivaTPSGRC.OK,
                 0
             )
 

--- a/src/geocompy/vivatps/__init__.py
+++ b/src/geocompy/vivatps/__init__.py
@@ -192,8 +192,7 @@ class VivaTPS(GeoComProtocol):
         for i in range(retry):
             try:
                 self._conn.send("\n")
-                response = self.com.nullprocess()
-                if not response.error:
+                if self.com.nullprocess():
                     sleep(1)
                     break
             except Exception:


### PR DESCRIPTION
Although all a GeoCom response string contains a separate communication and an RCP return code, it seems that only every one of them can be other than ``OK``.

This is also supported by the fact, that the C/C++ function call protocol also only returns a single return code, instead of two.