### PR TITLE
GeoCom methods refactor

### DIFF
--- a/src/geocompy/tps1000/__init__.py
+++ b/src/geocompy/tps1000/__init__.py
@@ -31,17 +31,11 @@ from __future__ import annotations
 import re
 import logging
 from time import sleep
-from traceback import format_exc
-from typing import Callable, Iterable, Any, overload, TypeVar
+from typing import TypeVar
 
-from serial import SerialException, SerialTimeoutException
-
-from ..data import (
-    Angle,
-    Byte
-)
 from ..communication import Connection
 from ..protocols import (
+    GeoComReturnCode,
     GeoComProtocol,
     GeoComResponse
 )
@@ -106,6 +100,14 @@ class TPS1000(GeoComProtocol):
         r"(?P<rc>\d+)"
         r"(?:,(?P<params>.*))?$"
     )
+    _RPCNAMES: dict[int, str] = rpcnames
+    _CODES: type[GeoComReturnCode] = TPS1000RC
+    _OK: GeoComReturnCode = TPS1000RC.OK
+    _FAILED: GeoComReturnCode = TPS1000RC.COM_FAILED
+    _CANTDECODE: GeoComReturnCode = TPS1000RC.COM_CANT_DECODE
+    _CANTSEND: GeoComReturnCode = TPS1000RC.COM_CANT_SEND
+    _TIMEOUT: GeoComReturnCode = TPS1000RC.COM_TIMEDOUT
+    _UNDEF: GeoComReturnCode = TPS1000RC.UNDEFINED
 
     REF_VERSION = (2, 20)
     """
@@ -185,10 +187,10 @@ class TPS1000(GeoComProtocol):
                 "could not establish connection to instrument"
             )
 
-        self._precision = 15
         resp = self.get_double_precision()
         if resp.params is not None:
             self._precision = resp.params
+            self._logger.info(f"Synced double precision: {self._precision}")
         else:
             self._logger.error(
                 f"Could not syncronize double precision, "
@@ -254,264 +256,3 @@ class TPS1000(GeoComProtocol):
         if not response.error:
             self._precision = digits
         return response
-
-    @overload
-    def request(
-        self,
-        rpc: int,
-        params: Iterable[int | float | bool | str | Angle | Byte] = (),
-        parsers: Callable[[str], _T] | None = None
-    ) -> GeoComResponse[_T]: ...
-
-    @overload
-    def request(
-        self,
-        rpc: int,
-        params: Iterable[int | float | bool | str | Angle | Byte] = (),
-        parsers: Iterable[Callable[[str], Any]] | None = None
-    ) -> GeoComResponse[tuple]: ...
-
-    def request(
-        self,
-        rpc: int,
-        params: Iterable[int | float | bool | str | Angle | Byte] = (),
-        parsers: (
-            Iterable[Callable[[str], Any]]
-            | Callable[[str], Any]
-            | None
-        ) = None
-    ) -> GeoComResponse:
-        """
-        Executes a TPS1000 RPC request and returns the parsed GeoCom
-        response.
-
-        Constructs a request(from the given RPC code and parameters),
-        writes it to the serial line, then reads the response. The
-        response is then parsed using the provided parser functions.
-
-        Parameters
-        ----------
-        rpc: int
-            Number of the RPC to execute.
-        params: Iterable[int | float | bool | str | Angle | Byte]
-            Parameters for the request, by default()
-        parsers: Iterable[Callable[[str], Any]] \
-                  | Callable[[str], Any] \
-                  | None, optional
-            Parser functions for the values in the RPC response,
-            by default None
-
-        Returns
-        -------
-        GeoComResponse
-            Parsed return codes and parameters from the RPC response.
-
-        Raises
-        ------
-        TypeError
-            If the passed parameters contained an unexpected type.
-
-        Notes
-        -----
-        If a: class: `~serial.SerialTimeoutException` occurs during the
-        request, a response with: attr: `~grc.TPS1000RC.COM_TIMEDOUT`
-        and: attr: `~grc.TPS1000RC.FATAL` codes is returned.
-
-        If a: class: `~serial.SerialException` occurs during the requrest,
-        a response with: attr: `~grc.TPS1000RC.COM_CANT_SEND` and
-        : attr: `~grc.TPS1000RC.FATAL` codes is returned.
-
-        If an unknown: class: `Exception` occurs during the request, a
-        response with: attr: `~grc.TPS1000RC.FATAL` and
-        : attr: `~grc.TPS1000RC.FATAL` codes is returned.
-
-        Examples
-        --------
-
-        Executing a command without input or output parameters:
-
-        >> > ts  # Instantiated TPS1000
-        >> > ts.request(9013)  # AUT_LockIn
-
-        Query command with output:
-
-        >> > ts.request(
-        ...     9030,  # AUT_GetFineAdjustMode
-        ...     [enumparser(ts.aut.ADJMODE)]
-        ...)
-
-        Execute command with both input and output parameters:
-
-        >> > ts.request(
-        ...     2108,  # TMC_GetSimpleMea
-        ...     [5000, ts.tmc.INCLINEPRG.AUTO.value],
-        ...     [
-        ...         Angle.parse,
-        ...         Angle.parse,
-        ...         float
-        ...]
-        ...)
-        """
-        strparams: list[str] = []
-        for item in params:
-            match item:
-                case Angle():
-                    value = f"{round(float(item), self._precision):f}"
-                    value = value.rstrip("0")
-                    if value[-1] == ".":
-                        value += "0"
-                case Byte():
-                    value = str(item)
-                case float():
-                    value = f"{round(item, self._precision):f}".rstrip("0")
-                    if value[-1] == ".":
-                        value += "0"
-                case int():
-                    value = f"{item:d}"
-                case str():
-                    value = f"\"{item}\""
-                case _:
-                    raise TypeError(f"unexpected parameter type: {type(item)}")
-
-            strparams.append(value)
-
-        cmd = f"%R1Q,{rpc}:{','.join(strparams)}"
-        try:
-            answer = self._conn.exchange(cmd)
-        except SerialTimeoutException:
-            self._logger.error(format_exc())
-            answer = (
-                f"%R1P,{TPS1000RC.COM_TIMEDOUT:d},"
-                f"0:{TPS1000RC.OK:d}"
-            )
-        except SerialException:
-            self._logger.error(format_exc())
-            answer = (
-                f"%R1P,{TPS1000RC.COM_CANT_SEND:d},"
-                f"0:{TPS1000RC.OK:d}"
-            )
-        except Exception:
-            self._logger.error(format_exc())
-            answer = (
-                f"%R1P,{TPS1000RC.COM_FAILED:d},"
-                f"0:{TPS1000RC.OK:d}"
-            )
-
-        response = self.parse_response(
-            cmd,
-            answer,
-            parsers
-        )
-        self._logger.debug(response)
-        return response
-
-    @overload
-    def parse_response(
-        self,
-        cmd: str,
-        response: str,
-        parsers: Callable[[str], _T] | None = None
-    ) -> GeoComResponse[_T]: ...
-
-    @overload
-    def parse_response(
-        self,
-        cmd: str,
-        response: str,
-        parsers: Iterable[Callable[[str], Any]] | None = None
-    ) -> GeoComResponse[tuple]: ...
-
-    def parse_response(
-        self,
-        cmd: str,
-        response: str,
-        parsers: (
-            Iterable[Callable[[str], Any]]
-            | Callable[[str], Any]
-            | None
-        ) = None
-    ) -> GeoComResponse:
-        """
-        Parses RPC response and constructs GeoComResponse
-        instance.
-
-        Parameters
-        ----------
-        cmd: str
-            Full, serialized request, that invoked the response.
-        response: str
-            Full, received response.
-        parsers: Iterable[Callable[[str], Any]] \
-                  | Callable[[str], Any] \
-                  | None, optional
-            Parser functions for the values in the RPC response,
-            by default None
-
-        Returns
-        -------
-        GeoComResponse
-            Parsed return codes and parameters from the RPC response.
-
-        Notes
-        -----
-        If the response does not match the expected pattern, or an
-        : class: `Exception` occurs during parsing, a response with
-        : attr: `~grc.TPS1000RC.COM_CANT_DECODE` and
-        : attr: `~grc.TPS1000RC.UNDEFINED` codes is returned.
-        """
-        m = self._RESPPAT.match(response)
-        rpc = int(cmd.split(":")[0].split(",")[1])
-        rpcname = rpcnames.get(rpc, str(rpc))
-        if not m:
-            return GeoComResponse(
-                rpcname,
-                cmd,
-                response,
-                TPS1000RC.COM_CANT_DECODE,
-                TPS1000RC.OK,
-                0
-            )
-
-        groups = m.groupdict()
-        values = groups.get("params", "")
-        if values is None:
-            values = ""
-
-        if parsers is None:
-            parsers = ()
-        elif not isinstance(parsers, Iterable):
-            parsers = (parsers,)
-
-        params: list = []
-        try:
-            for func, value in zip(parsers, values.split(",")):
-                params.append(func(value))
-        except Exception:
-            return GeoComResponse(
-                rpcname,
-                cmd,
-                response,
-                TPS1000RC.COM_CANT_DECODE,
-                TPS1000RC.OK,
-                0
-            )
-
-        comrc = TPS1000RC(int(groups["comrc"]))
-        rc = TPS1000RC(int(groups["rc"]))
-        match len(params):
-            case 0:
-                params_final = None
-            case 1:
-                params_final = params[0]
-            case _:
-                params_final = tuple(params)
-
-        return GeoComResponse(
-            rpcname,
-            cmd,
-            response,
-            comrc,
-            rc,
-            int(groups["tr"]),
-            params_final
-        )

--- a/src/geocompy/tps1000/__init__.py
+++ b/src/geocompy/tps1000/__init__.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import logging
 from time import sleep
-from typing import TypeVar
 
 from ..communication import Connection
 from ..protocols import (
@@ -50,9 +49,6 @@ from .sup import TPS1000SUP
 from .tmc import TPS1000TMC
 from .wir import TPS1000WIR
 from .rc import TPS1000RC, rpcnames
-
-
-_T = TypeVar("_T")
 
 
 class TPS1000(GeoComProtocol):

--- a/src/geocompy/tps1000/__init__.py
+++ b/src/geocompy/tps1000/__init__.py
@@ -28,7 +28,6 @@ Submodules
 """
 from __future__ import annotations
 
-import re
 import logging
 from time import sleep
 from typing import TypeVar
@@ -93,13 +92,6 @@ class TPS1000(GeoComProtocol):
     GeoComResponse(COM_GetDoublePrecision) ... # Precision sync
     GeoComResponse(COM_NullProc) ... # First executed command
     """
-    _RESPPAT: re.Pattern = re.compile(
-        r"^%R1P,"
-        r"(?P<comrc>\d+),"
-        r"(?P<tr>\d+):"
-        r"(?P<rc>\d+)"
-        r"(?:,(?P<params>.*))?$"
-    )
     _RPCNAMES: dict[int, str] = rpcnames
     _CODES: type[GeoComReturnCode] = TPS1000RC
     _OK: GeoComReturnCode = TPS1000RC.OK

--- a/src/geocompy/tps1100/__init__.py
+++ b/src/geocompy/tps1100/__init__.py
@@ -31,20 +31,13 @@ Submodules
 """
 from __future__ import annotations
 
-import re
 import logging
 from time import sleep
-from traceback import format_exc
-from typing import Callable, Iterable, Any, overload, TypeVar
+from typing import TypeVar
 
-from serial import SerialException, SerialTimeoutException
-
-from ..data import (
-    Angle,
-    Byte
-)
 from ..communication import Connection
 from ..protocols import (
+    GeoComReturnCode,
     GeoComProtocol,
     GeoComResponse
 )
@@ -103,13 +96,14 @@ class TPS1100(GeoComProtocol):
     GeoComResponse(COM_GetDoublePrecision) ... # Precision sync
     GeoComResponse(COM_NullProc) ... # First executed command
     """
-    _RESPPAT: re.Pattern = re.compile(
-        r"^%R1P,"
-        r"(?P<comrc>\d+),"
-        r"(?P<tr>\d+):"
-        r"(?P<rc>\d+)"
-        r"(?:,(?P<params>.*))?$"
-    )
+    _RPCNAMES: dict[int, str] = rpcnames
+    _CODES: type[GeoComReturnCode] = TPS1100RC
+    _OK: GeoComReturnCode = TPS1100RC.OK
+    _FAILED: GeoComReturnCode = TPS1100RC.COM_FAILED
+    _CANTDECODE: GeoComReturnCode = TPS1100RC.COM_CANT_DECODE
+    _CANTSEND: GeoComReturnCode = TPS1100RC.COM_CANT_SEND
+    _TIMEOUT: GeoComReturnCode = TPS1100RC.COM_TIMEDOUT
+    _UNDEF: GeoComReturnCode = TPS1100RC.UNDEFINED
 
     REF_VERSION = (1, 5)
     """
@@ -191,10 +185,10 @@ class TPS1100(GeoComProtocol):
                 "could not establish connection to instrument"
             )
 
-        self._precision = 15
         resp = self.get_double_precision()
         if resp.params is not None:
             self._precision = resp.params
+            self._logger.info(f"Synced double precision: {self._precision}")
         else:
             self._logger.error(
                 f"Could not syncronize double precision, "
@@ -260,264 +254,3 @@ class TPS1100(GeoComProtocol):
         if not response.error:
             self._precision = digits
         return response
-
-    @overload
-    def request(
-        self,
-        rpc: int,
-        params: Iterable[int | float | bool | str | Angle | Byte] = (),
-        parsers: Callable[[str], _T] | None = None
-    ) -> GeoComResponse[_T]: ...
-
-    @overload
-    def request(
-        self,
-        rpc: int,
-        params: Iterable[int | float | bool | str | Angle | Byte] = (),
-        parsers: Iterable[Callable[[str], Any]] | None = None
-    ) -> GeoComResponse[tuple]: ...
-
-    def request(
-        self,
-        rpc: int,
-        params: Iterable[int | float | bool | str | Angle | Byte] = (),
-        parsers: (
-            Iterable[Callable[[str], Any]]
-            | Callable[[str], Any]
-            | None
-        ) = None
-    ) -> GeoComResponse:
-        """
-        Executes a TPS1100 RPC request and returns the parsed GeoCom
-        response.
-
-        Constructs a request(from the given RPC code and parameters),
-        writes it to the serial line, then reads the response. The
-        response is then parsed using the provided parser functions.
-
-        Parameters
-        ----------
-        rpc: int
-            Number of the RPC to execute.
-        params: Iterable[int | float | bool | str | Angle | Byte]
-            Parameters for the request, by default()
-        parsers: Iterable[Callable[[str], Any]] \
-                  | Callable[[str], Any] \
-                  | None, optional
-            Parser functions for the values in the RPC response,
-            by default None
-
-        Returns
-        -------
-        GeoComResponse
-            Parsed return codes and parameters from the RPC response.
-
-        Raises
-        ------
-        TypeError
-            If the passed parameters contained an unexpected type.
-
-        Notes
-        -----
-        If a: class: `~serial.SerialTimeoutException` occurs during the
-        request, a response with: attr: `~grc.TPS1100RC.COM_TIMEDOUT`
-        and: attr: `~grc.TPS1100RC.FATAL` codes is returned.
-
-        If a: class: `~serial.SerialException` occurs during the requrest,
-        a response with: attr: `~grc.TPS1100RC.COM_CANT_SEND` and
-        : attr: `~grc.TPS1100RC.FATAL` codes is returned.
-
-        If an unknown: class: `Exception` occurs during the request, a
-        response with: attr: `~grc.TPS1100RC.FATAL` and
-        : attr: `~grc.TPS1100RC.FATAL` codes is returned.
-
-        Examples
-        --------
-
-        Executing a command without input or output parameters:
-
-        >> > ts  # Instantiated TPS1100
-        >> > ts.request(9013)  # AUT_LockIn
-
-        Query command with output:
-
-        >> > ts.request(
-        ...     9030,  # AUT_GetFineAdjustMode
-        ...     [enumparser(ts.aut.ADJMODE)]
-        ...)
-
-        Execute command with both input and output parameters:
-
-        >> > ts.request(
-        ...     2108,  # TMC_GetSimpleMea
-        ...     [5000, ts.tmc.INCLINEPRG.AUTO.value],
-        ...     [
-        ...         Angle.parse,
-        ...         Angle.parse,
-        ...         float
-        ...]
-        ...)
-        """
-        strparams: list[str] = []
-        for item in params:
-            match item:
-                case Angle():
-                    value = f"{round(float(item), self._precision):f}"
-                    value = value.rstrip("0")
-                    if value[-1] == ".":
-                        value += "0"
-                case Byte():
-                    value = str(item)
-                case float():
-                    value = f"{round(item, self._precision):f}".rstrip("0")
-                    if value[-1] == ".":
-                        value += "0"
-                case int():
-                    value = f"{item:d}"
-                case str():
-                    value = f"\"{item}\""
-                case _:
-                    raise TypeError(f"unexpected parameter type: {type(item)}")
-
-            strparams.append(value)
-
-        cmd = f"%R1Q,{rpc}:{','.join(strparams)}"
-        try:
-            answer = self._conn.exchange(cmd)
-        except SerialTimeoutException:
-            self._logger.error(format_exc())
-            answer = (
-                f"%R1P,{TPS1100RC.COM_TIMEDOUT:d},"
-                f"0:{TPS1100RC.OK:d}"
-            )
-        except SerialException:
-            self._logger.error(format_exc())
-            answer = (
-                f"%R1P,{TPS1100RC.COM_CANT_SEND:d},"
-                f"0:{TPS1100RC.OK:d}"
-            )
-        except Exception:
-            self._logger.error(format_exc())
-            answer = (
-                f"%R1P,{TPS1100RC.COM_FAILED:d},"
-                f"0:{TPS1100RC.OK:d}"
-            )
-
-        response = self.parse_response(
-            cmd,
-            answer,
-            parsers
-        )
-        self._logger.debug(response)
-        return response
-
-    @overload
-    def parse_response(
-        self,
-        cmd: str,
-        response: str,
-        parsers: Callable[[str], _T] | None = None
-    ) -> GeoComResponse[_T]: ...
-
-    @overload
-    def parse_response(
-        self,
-        cmd: str,
-        response: str,
-        parsers: Iterable[Callable[[str], Any]] | None = None
-    ) -> GeoComResponse[tuple]: ...
-
-    def parse_response(
-        self,
-        cmd: str,
-        response: str,
-        parsers: (
-            Iterable[Callable[[str], Any]]
-            | Callable[[str], Any]
-            | None
-        ) = None
-    ) -> GeoComResponse:
-        """
-        Parses RPC response and constructs GeoComResponse
-        instance.
-
-        Parameters
-        ----------
-        cmd: str
-            Full, serialized request, that invoked the response.
-        response: str
-            Full, received response.
-        parsers: Iterable[Callable[[str], Any]] \
-                  | Callable[[str], Any] \
-                  | None, optional
-            Parser functions for the values in the RPC response,
-            by default None
-
-        Returns
-        -------
-        GeoComResponse
-            Parsed return codes and parameters from the RPC response.
-
-        Notes
-        -----
-        If the response does not match the expected pattern, or an
-        : class: `Exception` occurs during parsing, a response with
-        : attr: `~grc.TPS1100RC.COM_CANT_DECODE` and
-        : attr: `~grc.TPS1100RC.UNDEFINED` codes is returned.
-        """
-        m = self._RESPPAT.match(response)
-        rpc = int(cmd.split(":")[0].split(",")[1])
-        rpcname = rpcnames.get(rpc, str(rpc))
-        if not m:
-            return GeoComResponse(
-                rpcname,
-                cmd,
-                response,
-                TPS1100RC.COM_CANT_DECODE,
-                TPS1100RC.OK,
-                0
-            )
-
-        groups = m.groupdict()
-        values = groups.get("params", "")
-        if values is None:
-            values = ""
-
-        if parsers is None:
-            parsers = ()
-        elif not isinstance(parsers, Iterable):
-            parsers = (parsers,)
-
-        params: list = []
-        try:
-            for func, value in zip(parsers, values.split(",")):
-                params.append(func(value))
-        except Exception:
-            return GeoComResponse(
-                rpcname,
-                cmd,
-                response,
-                TPS1100RC.COM_CANT_DECODE,
-                TPS1100RC.OK,
-                0
-            )
-
-        comrc = TPS1100RC(int(groups["comrc"]))
-        rc = TPS1100RC(int(groups["rc"]))
-        match len(params):
-            case 0:
-                params_final = None
-            case 1:
-                params_final = params[0]
-            case _:
-                params_final = tuple(params)
-
-        return GeoComResponse(
-            rpcname,
-            cmd,
-            response,
-            comrc,
-            rc,
-            int(groups["tr"]),
-            params_final
-        )

--- a/src/geocompy/tps1100/__init__.py
+++ b/src/geocompy/tps1100/__init__.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 
 import logging
 from time import sleep
-from typing import TypeVar
 
 from ..communication import Connection
 from ..protocols import (
@@ -54,9 +53,6 @@ from .sup import TPS1100SUP
 from .tmc import TPS1100TMC
 from .wir import TPS1100WIR
 from .rc import TPS1100RC, rpcnames
-
-
-_T = TypeVar("_T")
 
 
 class TPS1100(GeoComProtocol):

--- a/src/geocompy/vivatps/__init__.py
+++ b/src/geocompy/vivatps/__init__.py
@@ -35,20 +35,12 @@ Submodules
 """
 from __future__ import annotations
 
-import re
 import logging
 from time import sleep
-from traceback import format_exc
-from typing import Callable, Iterable, Any, overload, TypeVar
 
-from serial import SerialException, SerialTimeoutException
-
-from ..data import (
-    Angle,
-    Byte
-)
 from ..communication import Connection
 from ..protocols import (
+    GeoComReturnCode,
     GeoComProtocol,
     GeoComResponse
 )
@@ -67,9 +59,6 @@ from .mot import VivaTPSMOT
 from .sup import VivaTPSSUP
 from .tmc import VivaTPSTMC
 from .grc import VivaTPSGRC, rpcnames
-
-
-_T = TypeVar("_T")
 
 
 class VivaTPS(GeoComProtocol):
@@ -110,14 +99,14 @@ class VivaTPS(GeoComProtocol):
     GeoComResponse(COM_NullProc) ... # First executed command
 
     """
-    _RESPPAT: re.Pattern = re.compile(
-        r"^%R1P,"
-        r"(?P<comrc>\d+),"
-        r"(?P<tr>\d+)"
-        r"(?:,(?P<chk>\d+))?:"
-        r"(?P<rc>\d+)"
-        r"(?:,(?P<params>.*))?$"
-    )
+    _RPCNAMES: dict[int, str] = rpcnames
+    _CODES: type[GeoComReturnCode] = VivaTPSGRC
+    _OK: GeoComReturnCode = VivaTPSGRC.OK
+    _FAILED: GeoComReturnCode = VivaTPSGRC.COM_FAILED
+    _CANTDECODE: GeoComReturnCode = VivaTPSGRC.COM_CANT_DECODE
+    _CANTSEND: GeoComReturnCode = VivaTPSGRC.COM_CANT_SEND
+    _TIMEOUT: GeoComReturnCode = VivaTPSGRC.COM_TIMEDOUT
+    _UNDEF: GeoComReturnCode = VivaTPSGRC.UNDEFINED
 
     REF_VERSION = (5, 51)
     """
@@ -208,6 +197,7 @@ class VivaTPS(GeoComProtocol):
         resp = self.get_double_precision()
         if resp.params is not None:
             self._precision = resp.params
+            self._logger.info(f"Synced double precision: {self._precision}")
         else:
             self._logger.error(
                 f"Could not syncronize double precision, "
@@ -275,268 +265,3 @@ class VivaTPS(GeoComProtocol):
         if not response.error:
             self._precision = digits
         return response
-
-    @overload
-    def request(
-        self,
-        rpc: int,
-        params: Iterable[int | float | bool | str | Angle | Byte] = (),
-        parsers: Callable[[str], _T] | None = None
-    ) -> GeoComResponse[_T]: ...
-
-    @overload
-    def request(
-        self,
-        rpc: int,
-        params: Iterable[int | float | bool | str | Angle | Byte] = (),
-        parsers: Iterable[Callable[[str], Any]] | None = None
-    ) -> GeoComResponse[tuple]: ...
-
-    def request(
-        self,
-        rpc: int,
-        params: Iterable[int | float | bool | str | Angle | Byte] = [],
-        parsers: (
-            Iterable[Callable[[str], Any]]
-            | Callable[[str], Any]
-            | None
-        ) = None
-    ) -> GeoComResponse:
-        """
-        Executes a VivaTPS RPC request and returns the parsed GeoCom
-        response.
-
-        Constructs a request (from the given RPC code and parameters),
-        writes it to the serial line, then reads the response. The
-        response is then parsed using the provided parser functions.
-
-        Parameters
-        ----------
-        rpc : int
-            Number of the RPC to execute.
-        params : Iterable[int | float | bool | str | Angle | Byte]
-            Parameters for the request, by default ()
-        parsers : Iterable[Callable[[str], Any]] \
-                  | Callable[[str], Any] \
-                  | None, optional
-            Parser functions for the values in the RPC response,
-            by default None
-
-        Returns
-        -------
-        GeoComResponse
-            Parsed return codes and parameters from the RPC response.
-
-        Raises
-        ------
-        TypeError
-            If the passed parameters contained an unexpected type.
-
-        Notes
-        -----
-        If a :class:`~serial.SerialTimeoutException` occurs during the
-        request, a response with :attr:`~grc.VivaTPSGRC.COM_TIMEDOUT`
-        and :attr:`~grc.VivaTPSGRC.FATAL` codes is returned.
-
-        If a :class:`~serial.SerialException` occurs during the requrest,
-        a response with :attr:`~grc.VivaTPSGRC.COM_CANT_SEND` and
-        :attr:`~grc.VivaTPSGRC.FATAL` codes is returned.
-
-        If an unknown :class:`Exception` occurs during the request, a
-        response with :attr:`~grc.VivaTPSGRC.FATAL` and
-        :attr:`~grc.VivaTPSGRC.FATAL` codes is returned.
-
-        Examples
-        --------
-
-        Executing a command without input or output parameters:
-
-        >>> ts # Instantiated VivaTPS
-        >>> ts.request(9013) # AUT_LockIn
-
-        Query command with output:
-
-        >>> ts.request(
-        ...     9030, # AUT_GetFineAdjustMode
-        ...     parsers={
-        ...         "adjmode": ts.aut.ADJMODE.parse
-        ...     }
-        ... )
-
-        Execute command with both input and output parameters:
-
-        >>> ts.request(
-        ...     2108, # TMC_GetSimpleMea
-        ...     [5000, ts.tmc.INCLINEPRG.AUTO.value],
-        ...     {
-        ...         "hz": Angle.parse,
-        ...         "v": Angle.parse,
-        ...         "dist": float
-        ...     }
-        ... )
-
-        """
-        strparams: list[str] = []
-        for item in params:
-            match item:
-                case Angle():
-                    value = f"{round(float(item), self._precision):f}"
-                    value = value.rstrip("0")
-                    if value[-1] == ".":
-                        value += "0"
-                case Byte():
-                    value = str(item)
-                case float():
-                    value = f"{round(item, self._precision):f}".rstrip("0")
-                    if value[-1] == ".":
-                        value += "0"
-                case int():
-                    value = f"{item:d}"
-                case str():
-                    value = f"\"{item}\""
-                case _:
-                    raise TypeError(f"unexpected parameter type: {type(item)}")
-
-            strparams.append(value)
-
-        cmd = f"%R1Q,{rpc}:{','.join(strparams)}"
-        try:
-            answer = self._conn.exchange(cmd)
-        except SerialTimeoutException:
-            self._logger.error(format_exc())
-            answer = (
-                f"%R1P,{VivaTPSGRC.COM_TIMEDOUT:d},"
-                f"0:{VivaTPSGRC.OK:d}"
-            )
-        except SerialException:
-            self._logger.error(format_exc())
-            answer = (
-                f"%R1P,{VivaTPSGRC.COM_CANT_SEND:d},"
-                f"0:{VivaTPSGRC.OK:d}"
-            )
-        except Exception:
-            self._logger.error(format_exc())
-            answer = (
-                f"%R1P,{VivaTPSGRC.COM_FAILED:d},"
-                f"0:{VivaTPSGRC.OK:d}"
-            )
-
-        response = self.parse_response(
-            cmd,
-            answer,
-            parsers
-        )
-        self._logger.debug(response)
-        return response
-
-    @overload
-    def parse_response(
-        self,
-        cmd: str,
-        response: str,
-        parsers: Callable[[str], _T] | None = None
-    ) -> GeoComResponse[_T]: ...
-
-    @overload
-    def parse_response(
-        self,
-        cmd: str,
-        response: str,
-        parsers: Iterable[Callable[[str], Any]] | None = None
-    ) -> GeoComResponse[tuple]: ...
-
-    def parse_response(
-        self,
-        cmd: str,
-        response: str,
-        parsers: (
-            Iterable[Callable[[str], Any]]
-            | Callable[[str], Any]
-            | None
-        ) = None
-    ) -> GeoComResponse:
-        """
-        Parses RPC response and constructs GeoComResponse
-        instance.
-
-        Parameters
-        ----------
-        cmd : str
-            Full, serialized request, that invoked the response.
-        response : str
-            Full, received response.
-        parsers : Iterable[Callable[[str], Any]] \
-                  | Callable[[str], Any] \
-                  | None, optional
-            Parser functions for the values in the RPC response,
-            by default None
-
-        Returns
-        -------
-        GeoComResponse
-            Parsed return codes and parameters from the RPC response.
-
-        Notes
-        -----
-        If the response does not match the expected pattern, or an
-        :class:`Exception` occurs during parsing, a response with
-        :attr:`~grc.VivaTPSGRC.COM_CANT_DECODE` and
-        :attr:`~grc.VivaTPSGRC.UNDEFINED` codes is returned.
-
-        """
-        m = self._RESPPAT.match(response)
-        rpc = int(cmd.split(":")[0].split(",")[1])
-        rpcname = rpcnames.get(rpc, str(rpc))
-        if not m:
-            return GeoComResponse(
-                rpcname,
-                cmd,
-                response,
-                VivaTPSGRC.COM_CANT_DECODE,
-                VivaTPSGRC.OK,
-                0
-            )
-
-        groups = m.groupdict()
-        values = groups.get("params", "")
-        if values is None:
-            values = ""
-
-        if parsers is None:
-            parsers = ()
-        elif not isinstance(parsers, Iterable):
-            parsers = (parsers,)
-
-        params: list = []
-        try:
-            for func, value in zip(parsers, values.split(",")):
-                params.append(func(value))
-        except Exception:
-            return GeoComResponse(
-                rpcname,
-                cmd,
-                response,
-                VivaTPSGRC.COM_CANT_DECODE,
-                VivaTPSGRC.OK,
-                0
-            )
-
-        comrc = VivaTPSGRC(int(groups["comrc"]))
-        rc = VivaTPSGRC(int(groups["rc"]))
-        match len(params):
-            case 0:
-                params_final = None
-            case 1:
-                params_final = params[0]
-            case _:
-                params_final = tuple(params)
-
-        return GeoComResponse(
-            rpcname,
-            cmd,
-            response,
-            comrc,
-            rc,
-            int(groups["tr"]),
-            params_final
-        )


### PR DESCRIPTION
Currently all GeoCom instruments implement an almost identical `request` and `parse_response` function.

This PR extracts those functions into the common `GeoComProtocol` parent, and passes in the necessary constants as class variables, that need to be overwritten on the child classes to get the correct result.